### PR TITLE
refactor: CLI font and color as enums

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,21 +24,63 @@ If you don't have the rust toolchain, there are pre-built binaries in the releas
 Usage: tuime [OPTIONS]
 
 Options:
-      --format <FORMAT>          Format the time [default: %H:%M]
-  -c, --colors <COLORS>          Supply a color to use for rendering
-                                 If the font supports it you may supply mutliple colors : -c red -c green ...
-                                 To see what fonts support multiple colors, see https://github.com/dominikwilkowski/cfonts
-  -f, --font <FONT>              Set Font
-                                 To see what fonts you can use, go to https://github.com/dominikwilkowski/cfonts [default: Block]
-  -g, --gradient <GRADIENT>      Set a gradient
-                                 use a gradient instead of regular colors : -g "\#ffaabb" -g "\#ee22ff" ...
-  -u, --utc-offset <UTC_OFFSET>  Set the utc offset
-                                 If this argument is not supplied, we will try to use the local time
-                                 Supplied as +/-<secs>. Eg: tuime -u="-3600", tuime -u="+7200"
+      --format <FORMAT>
+          Format the time
 
-  -h, --help                     Print help
-  -V, --version                  Print version
+          [default: %H:%M]
 
+  -c, --colors <COLORS>
+          Supply a color to use for rendering
+
+          If the font supports it you may supply mutliple colors : -c red -c green ...
+          To see what fonts support multiple colors, see https://github.com/dominikwilkowski/cfonts"
+
+          Possible values:
+          - system:
+            Uses the system font defined by your console
+          - black
+          - red
+          - green
+          - yellow
+          - blue
+          - magenta
+          - cyan
+          - white
+          - gray
+          - red-bright
+          - green-bright
+          - yellow-bright
+          - blue-bright
+          - magenta-bright
+          - cyan-bright
+          - white-bright
+          - candy:
+            A color that randomizes it's colors from a set of bright candy-like color set
+
+  -f, --font <FONT>
+          Set the font
+          To see what fonts you can use, go to https://github.com/dominikwilkowski/cfonts"
+
+          [default: font-block]
+          [possible values: font-console, font-block, font-simple-block, font-simple, font3d, font-simple3d, font-chrome, font-huge, font-shade, font-slick, font-grid, font-pallet, font-tiny]
+
+  -g, --gradient <GRADIENT>
+          Set a gradient instead of regular colors : -g "#ffaabb" -g "#ee22ff" ..."
+
+  -u, --utc-offset <UTC_OFFSET>
+          Set the utc offset
+
+          If this argument is not supplied, we will try to use the local time
+          Supplied as +/-<secs>. Eg: tuime -u="-3600", tuime -u="+7200"
+
+  -s, --screensaver
+          Screensaver mode
+
+  -h, --help
+          Print help (see a summary with '-h')
+
+  -V, --version
+          Print version
 ```
 
 ### Red and Black with Regular Font

--- a/src/args.rs
+++ b/src/args.rs
@@ -1,5 +1,5 @@
-use clap::Parser;
 use crate::{colors::Colors, fonts::Fonts};
+use clap::Parser;
 
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
@@ -17,13 +17,7 @@ pub struct Args {
 
     /// Set the font
     /// To see what fonts you can use, go to https://github.com/dominikwilkowski/cfonts"
-    #[arg(
-        short, 
-        long, 
-        value_enum,
-        default_value_t = Fonts::FontBlock,
-        verbatim_doc_comment
-    )]
+    #[arg(short, long, value_enum, default_value_t = Fonts::FontBlock, verbatim_doc_comment)]
     pub font: Fonts,
 
     /// Set a gradient instead of regular colors : -g "#ffaabb" -g "#ee22ff" ..."

--- a/src/args.rs
+++ b/src/args.rs
@@ -1,4 +1,5 @@
 use clap::Parser;
+use crate::{colors::Colors, fonts::Fonts};
 
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
@@ -7,39 +8,36 @@ pub struct Args {
     #[arg(long, default_value_t = String::from("%H:%M"))]
     pub format: String,
 
-    #[arg(
-        short,
-        long,
-        help = 
-r"Supply a color to use for rendering
-If the font supports it you may supply mutliple colors : -c red -c green ...
-To see what fonts support multiple colors, see https://github.com/dominikwilkowski/cfonts"
-    )]
-    pub colors: Vec<String>,
+    /// Supply a color to use for rendering
+    ///
+    /// If the font supports it you may supply mutliple colors : -c red -c green ...
+    /// To see what fonts support multiple colors, see https://github.com/dominikwilkowski/cfonts"
+    #[arg(short, long, value_enum, verbatim_doc_comment)]
+    pub colors: Vec<Colors>,
 
+    /// Set the font
+    /// To see what fonts you can use, go to https://github.com/dominikwilkowski/cfonts"
     #[arg(
         short, 
         long, 
-        default_value_t = String::from("Block"),
-        help = 
-r"Set Font
-To see what fonts you can use, go to https://github.com/dominikwilkowski/cfonts"
+        value_enum,
+        default_value_t = Fonts::FontBlock,
+        verbatim_doc_comment
     )]
-    pub font: String,
+    pub font: Fonts,
 
-    #[arg(short, long, help=
-r#"Set a gradient
-use a gradient instead of regular colors : -g "\#ffaabb" -g "\#ee22ff" ..."#
-    )]
+    /// Set a gradient instead of regular colors : -g "#ffaabb" -g "#ee22ff" ..."
+    #[arg(short, long, verbatim_doc_comment)]
     pub gradient: Vec<String>,
 
-    #[arg(short, long, help=
-r#"Set the utc offset 
-If this argument is not supplied, we will try to use the local time
-Supplied as +/-<secs>. Eg: tuime -u="-3600", tuime -u="+7200"
-"#)]
+    /// Set the utc offset
+    ///
+    /// If this argument is not supplied, we will try to use the local time
+    /// Supplied as +/-<secs>. Eg: tuime -u="-3600", tuime -u="+7200"
+    #[arg(short, long, verbatim_doc_comment)]
     pub utc_offset: Option<i32>,
 
-    #[arg(short, long, help="Screensaver mode")]
+    /// Screensaver mode
+    #[arg(short, long)]
     pub screensaver: bool,
 }

--- a/src/colors.rs
+++ b/src/colors.rs
@@ -1,0 +1,62 @@
+use clap::ValueEnum;
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, ValueEnum)]
+pub enum Colors {
+    /// Uses the system font defined by your console
+    System,
+    Black,
+    Red,
+    Green,
+    Yellow,
+    Blue,
+    Magenta,
+    Cyan,
+    White,
+    Gray,
+    RedBright,
+    GreenBright,
+    YellowBright,
+    BlueBright,
+    MagentaBright,
+    CyanBright,
+    WhiteBright,
+    /// A color that randomizes it's colors from a set of bright candy-like color set.
+    Candy,
+    // /// `Rgb` allows you to use colors outside the traditional ansi16 color set.
+    // /// It's value is the [`Rgb`] enum that has a single value called `Val`.
+    // Rgb(Rgb),
+}
+
+impl From<Colors> for cfonts::Colors {
+    fn from(c: Colors) -> Self {
+        match c {
+            Colors::System => cfonts::Colors::System,
+            Colors::Black => cfonts::Colors::Black,
+            Colors::Red => cfonts::Colors::Red,
+            Colors::Green => cfonts::Colors::Green,
+            Colors::Yellow => cfonts::Colors::Yellow,
+            Colors::Blue => cfonts::Colors::Blue,
+            Colors::Magenta => cfonts::Colors::Magenta,
+            Colors::Cyan => cfonts::Colors::Cyan,
+            Colors::White => cfonts::Colors::White,
+            Colors::Gray => cfonts::Colors::Gray,
+            Colors::RedBright => cfonts::Colors::RedBright,
+            Colors::GreenBright => cfonts::Colors::GreenBright,
+            Colors::YellowBright => cfonts::Colors::YellowBright,
+            Colors::BlueBright => cfonts::Colors::BlueBright,
+            Colors::MagentaBright => cfonts::Colors::MagentaBright,
+            Colors::CyanBright => cfonts::Colors::CyanBright,
+            Colors::WhiteBright => cfonts::Colors::WhiteBright,
+            Colors::Candy => cfonts::Colors::Candy,
+        }
+    }
+}
+
+/// Colors vector new type wrapper
+pub struct ColorsVecNTWrapper(pub Vec<Colors>);
+
+impl Into<Vec<cfonts::Colors>> for ColorsVecNTWrapper {
+    fn into(self) -> Vec<cfonts::Colors> {
+        self.0.iter().map(|c| (*c).into()).collect()
+    }
+}

--- a/src/colors.rs
+++ b/src/colors.rs
@@ -55,8 +55,8 @@ impl From<Colors> for cfonts::Colors {
 /// Colors vector new type wrapper
 pub struct ColorsVecNTWrapper(pub Vec<Colors>);
 
-impl Into<Vec<cfonts::Colors>> for ColorsVecNTWrapper {
-    fn into(self) -> Vec<cfonts::Colors> {
-        self.0.iter().map(|c| (*c).into()).collect()
+impl From<ColorsVecNTWrapper> for Vec<cfonts::Colors> {
+    fn from(c: ColorsVecNTWrapper) -> Self {
+        c.0.iter().map(|c| (*c).into()).collect()
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -7,10 +7,10 @@ pub struct Config {
 }
 
 impl Config {
-    pub fn new(font: &Fonts, color: &Vec<Colors>) -> Self {
+    pub fn new(font: &Fonts, color: &[Colors]) -> Self {
         Self {
-            font: font.clone(),
-            color: color.clone(),
+            font: font.to_owned(),
+            color: color.to_owned(),
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,4 +1,5 @@
-use cfonts::{Fonts, Colors};
+use crate::colors::Colors;
+use crate::fonts::Fonts;
 
 pub struct Config {
     pub font: Fonts,
@@ -6,53 +7,53 @@ pub struct Config {
 }
 
 impl Config {
-    pub fn new(font: &str, color: Vec<String>) -> Self {
+    pub fn new(font: &Fonts, color: &Vec<Colors>) -> Self {
         Self {
-            font: font_from_str(font),
-            color: color.into_iter().map(color_from_str).collect(),
+            font: font.clone(),
+            color: color.clone(),
         }
     }
 }
 
-fn color_from_str(s: String) -> Colors {
-    match s.to_lowercase().as_str() {
-        "black" => Colors::Black,
-        "red" => Colors::Red,
-        "green" => Colors::Green,
-        "yellow" => Colors::Yellow,
-        "blue" => Colors::Blue,
-        "magenta" => Colors::Magenta,
-        "cyan" => Colors::Cyan,
-        "white" => Colors::White,
-        "gray" => Colors::Gray,
-        "redbright" => Colors::RedBright,
-        "greenbright" => Colors::GreenBright,
-        "yellowbright" => Colors::YellowBright,
-        "bluebright" => Colors::BlueBright,
-        "magentabright" => Colors::MagentaBright,
-        "cyanbright" => Colors::CyanBright,
-        "whitebright" => Colors::WhiteBright,
-        "candy" => Colors::Candy,
-        _ => Colors::System,
-    }
-}
-
-fn font_from_str(s: &str) -> Fonts {
-    match s.to_lowercase().as_str() {
-        "console" => Fonts::FontConsole,
-        "block" => Fonts::FontBlock,
-        "simpleblock" => Fonts::FontSimpleBlock,
-        "simple" => Fonts::FontSimple,
-        "3d" => Fonts::Font3d,
-        "simple3d" => Fonts::FontSimple3d,
-        "chrome" => Fonts::FontChrome,
-        "huge" => Fonts::FontHuge,
-        "shade" => Fonts::FontShade,
-        "slick" => Fonts::FontSlick,
-        "grid" => Fonts::FontGrid,
-        "pallet" => Fonts::FontPallet,
-        "tiny" => Fonts::FontTiny,
-        _ => Fonts::FontBlock,
-    }
-}
-
+// fn color_from_str(s: String) -> Colors {
+//     match s.to_lowercase().as_str() {
+//         "black" => Colors::Black,
+//         "red" => Colors::Red,
+//         "green" => Colors::Green,
+//         "yellow" => Colors::Yellow,
+//         "blue" => Colors::Blue,
+//         "magenta" => Colors::Magenta,
+//         "cyan" => Colors::Cyan,
+//         "white" => Colors::White,
+//         "gray" => Colors::Gray,
+//         "redbright" => Colors::RedBright,
+//         "greenbright" => Colors::GreenBright,
+//         "yellowbright" => Colors::YellowBright,
+//         "bluebright" => Colors::BlueBright,
+//         "magentabright" => Colors::MagentaBright,
+//         "cyanbright" => Colors::CyanBright,
+//         "whitebright" => Colors::WhiteBright,
+//         "candy" => Colors::Candy,
+//         _ => Colors::System,
+//     }
+// }
+//
+// fn font_from_str(s: &str) -> Fonts {
+//     match s.to_lowercase().as_str() {
+//         "console" => Fonts::FontConsole,
+//         "block" => Fonts::FontBlock,
+//         "simpleblock" => Fonts::FontSimpleBlock,
+//         "simple" => Fonts::FontSimple,
+//         "3d" => Fonts::Font3d,
+//         "simple3d" => Fonts::FontSimple3d,
+//         "chrome" => Fonts::FontChrome,
+//         "huge" => Fonts::FontHuge,
+//         "shade" => Fonts::FontShade,
+//         "slick" => Fonts::FontSlick,
+//         "grid" => Fonts::FontGrid,
+//         "pallet" => Fonts::FontPallet,
+//         "tiny" => Fonts::FontTiny,
+//         _ => Fonts::FontBlock,
+//     }
+// }
+//

--- a/src/display.rs
+++ b/src/display.rs
@@ -4,8 +4,8 @@ use cfonts::{render, Align, Options};
 use chrono::{FixedOffset, Utc};
 use crossterm::{cursor, style::Print, terminal, QueueableCommand};
 
-use crate::{args::Args, error::TuimeError, config::Config};
 use crate::colors::ColorsVecNTWrapper;
+use crate::{args::Args, config::Config, error::TuimeError};
 
 pub fn get_time_str(args: &Args, cfg: &Config) -> String {
     let time = match args.utc_offset.as_ref() {

--- a/src/display.rs
+++ b/src/display.rs
@@ -5,6 +5,7 @@ use chrono::{FixedOffset, Utc};
 use crossterm::{cursor, style::Print, terminal, QueueableCommand};
 
 use crate::{args::Args, error::TuimeError, config::Config};
+use crate::colors::ColorsVecNTWrapper;
 
 pub fn get_time_str(args: &Args, cfg: &Config) -> String {
     let time = match args.utc_offset.as_ref() {
@@ -18,9 +19,9 @@ pub fn get_time_str(args: &Args, cfg: &Config) -> String {
     let time_str = render(Options {
         text: time,
         align: Align::Center,
-        font: cfg.font.to_owned(),
+        font: cfg.font.to_owned().into(),
         gradient: args.gradient.clone(),
-        colors: cfg.color.to_owned(),
+        colors: ColorsVecNTWrapper(cfg.color.to_owned()).into(),
         ..Options::default()
     });
 

--- a/src/fonts.rs
+++ b/src/fonts.rs
@@ -1,0 +1,38 @@
+use clap::ValueEnum;
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, ValueEnum)]
+pub enum Fonts {
+	FontConsole,
+	FontBlock,
+	FontSimpleBlock,
+	FontSimple,
+	Font3d,
+	FontSimple3d,
+	FontChrome,
+	FontHuge,
+	FontShade,
+	FontSlick,
+	FontGrid,
+	FontPallet,
+	FontTiny,
+}
+
+impl Into<cfonts::Fonts> for Fonts {
+    fn into(self) -> cfonts::Fonts {
+        match self {
+            Fonts::FontConsole => cfonts::Fonts::FontConsole,
+            Fonts::FontBlock => cfonts::Fonts::FontBlock,
+            Fonts::FontSimpleBlock => cfonts::Fonts::FontSimpleBlock,
+            Fonts::FontSimple => cfonts::Fonts::FontSimple,
+            Fonts::Font3d => cfonts::Fonts::Font3d,
+            Fonts::FontSimple3d => cfonts::Fonts::FontSimple3d,
+            Fonts::FontChrome => cfonts::Fonts::FontChrome,
+            Fonts::FontHuge => cfonts::Fonts::FontHuge,
+            Fonts::FontShade => cfonts::Fonts::FontShade,
+            Fonts::FontSlick => cfonts::Fonts::FontSlick,
+            Fonts::FontGrid => cfonts::Fonts::FontGrid,
+            Fonts::FontPallet => cfonts::Fonts::FontPallet,
+            Fonts::FontTiny => cfonts::Fonts::FontTiny,
+        }
+    }
+}

--- a/src/fonts.rs
+++ b/src/fonts.rs
@@ -2,19 +2,19 @@ use clap::ValueEnum;
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, ValueEnum)]
 pub enum Fonts {
-	FontConsole,
-	FontBlock,
-	FontSimpleBlock,
-	FontSimple,
-	Font3d,
-	FontSimple3d,
-	FontChrome,
-	FontHuge,
-	FontShade,
-	FontSlick,
-	FontGrid,
-	FontPallet,
-	FontTiny,
+    FontConsole,
+    FontBlock,
+    FontSimpleBlock,
+    FontSimple,
+    Font3d,
+    FontSimple3d,
+    FontChrome,
+    FontHuge,
+    FontShade,
+    FontSlick,
+    FontGrid,
+    FontPallet,
+    FontTiny,
 }
 
 impl From<Fonts> for cfonts::Fonts {

--- a/src/fonts.rs
+++ b/src/fonts.rs
@@ -17,9 +17,9 @@ pub enum Fonts {
 	FontTiny,
 }
 
-impl Into<cfonts::Fonts> for Fonts {
-    fn into(self) -> cfonts::Fonts {
-        match self {
+impl From<Fonts> for cfonts::Fonts {
+    fn from(f: Fonts) -> Self {
+        match f {
             Fonts::FontConsole => cfonts::Fonts::FontConsole,
             Fonts::FontBlock => cfonts::Fonts::FontBlock,
             Fonts::FontSimpleBlock => cfonts::Fonts::FontSimpleBlock,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,5 @@
 use anyhow::Result;
 use clap::Parser;
-use config::Config;
 
 use std::time::Duration;
 use tokio::time::interval;
@@ -13,12 +12,16 @@ use crossterm::{
 
 use futures::{FutureExt, StreamExt};
 
+use crate::config::Config;
+use crate::args::Args;
+
 mod args;
 mod config;
 mod display;
 mod error;
 
-use args::Args;
+mod colors;
+mod fonts;
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -30,7 +33,7 @@ async fn main() -> Result<()> {
         cursor::Hide
     }?;
 
-    let cfg = Config::new(&args.font, args.colors.clone());
+    let cfg = Config::new(&args.font, &args.colors);
     let mut reader = EventStream::new();
     let mut interval = interval(Duration::from_secs(1));
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,8 +12,8 @@ use crossterm::{
 
 use futures::{FutureExt, StreamExt};
 
-use crate::config::Config;
 use crate::args::Args;
+use crate::config::Config;
 
 mod args;
 mod config;


### PR DESCRIPTION
Hi,

Great job with this project! Here is a list of the changes I've implemented.

- CLI now uses enums
  - Custom font and color enums
- Refactored CLI docs
- Fix `cargo clippy` warnings
- Update README.md usage
- Run `cargo fmt`