### PR TITLE
Fix Flicker: This time without artefacts

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1,9 +1,12 @@
+use std::cell::Cell;
 use crate::colors::Colors;
 use crate::fonts::Fonts;
 
 pub struct Config {
     pub font: Fonts,
     pub color: Vec<Colors>,
+    pub height: Cell<usize>,
+    pub width: Cell<usize>,
 }
 
 impl Config {
@@ -11,6 +14,8 @@ impl Config {
         Self {
             font: font.to_owned(),
             color: color.to_owned(),
+            width: Cell::new(0),
+            height: Cell::new(0)
         }
     }
 }

--- a/src/display.rs
+++ b/src/display.rs
@@ -2,6 +2,7 @@ use std::io::Write;
 
 use cfonts::{render, Align, Options};
 use chrono::{FixedOffset, Utc};
+use crossterm::terminal::{BeginSynchronizedUpdate, EndSynchronizedUpdate};
 use crossterm::{cursor, style::Print, terminal, QueueableCommand};
 
 use crate::colors::ColorsVecNTWrapper;
@@ -43,7 +44,8 @@ pub fn print_time(args: &Args, cfg: &Config) -> Result<(), TuimeError> {
         return Err(TuimeError::WindowTooSmall(width, height));
     };
     let mut stdout = std::io::stdout();
-
+    //stdout.queue(terminal::Clear(terminal::ClearType::All)).unwrap();
+    stdout.queue(BeginSynchronizedUpdate).unwrap();
     for (line_nr, line) in time_str.iter().enumerate() {
         stdout
         .queue(cursor::MoveTo(
@@ -53,9 +55,10 @@ pub fn print_time(args: &Args, cfg: &Config) -> Result<(), TuimeError> {
             .map_err(|_| TuimeError::WindowTooSmall(width, height))?,
         ))
         .unwrap();
-        crossterm::queue!(stdout, terminal::Clear(terminal::ClearType::CurrentLine), Print(line)).unwrap();
-        stdout.flush().unwrap();
+        crossterm::queue!(stdout,  Print(line), terminal::Clear(terminal::ClearType::UntilNewLine)).unwrap();
+        //stdout.flush().unwrap();
     }
-
+    stdout.queue(EndSynchronizedUpdate).unwrap()
+        .flush().unwrap();
     Ok(())
 }

--- a/src/display.rs
+++ b/src/display.rs
@@ -6,6 +6,7 @@ use crossterm::terminal::{BeginSynchronizedUpdate, EndSynchronizedUpdate};
 use crossterm::{cursor, style::Print, terminal, QueueableCommand};
 
 use crate::colors::ColorsVecNTWrapper;
+use crate::config;
 use crate::{args::Args, config::Config, error::TuimeError};
 
 pub fn get_time_str(args: &Args, cfg: &Config) -> String {
@@ -23,9 +24,11 @@ pub fn get_time_str(args: &Args, cfg: &Config) -> String {
         font: cfg.font.to_owned().into(),
         gradient: args.gradient.clone(),
         colors: ColorsVecNTWrapper(cfg.color.to_owned()).into(),
+    //    debug: true,
+    //    debug_level: 10,
         ..Options::default()
     });
-
+ 
     time_str.text
 }
 
@@ -44,7 +47,12 @@ pub fn print_time(args: &Args, cfg: &Config) -> Result<(), TuimeError> {
         return Err(TuimeError::WindowTooSmall(width, height));
     };
     let mut stdout = std::io::stdout();
-    //stdout.queue(terminal::Clear(terminal::ClearType::All)).unwrap();
+    
+    if height != cfg.height.get() || width != cfg.width.get() {
+        stdout.queue(terminal::Clear(terminal::ClearType::All)).unwrap();
+        cfg.height.set(height);
+        cfg.width.set(width);
+    }
     stdout.queue(BeginSynchronizedUpdate).unwrap();
     for (line_nr, line) in time_str.iter().enumerate() {
         stdout

--- a/src/display.rs
+++ b/src/display.rs
@@ -6,7 +6,6 @@ use crossterm::terminal::{BeginSynchronizedUpdate, EndSynchronizedUpdate};
 use crossterm::{cursor, style::Print, terminal, QueueableCommand};
 
 use crate::colors::ColorsVecNTWrapper;
-use crate::config;
 use crate::{args::Args, config::Config, error::TuimeError};
 
 pub fn get_time_str(args: &Args, cfg: &Config) -> String {
@@ -48,12 +47,12 @@ pub fn print_time(args: &Args, cfg: &Config) -> Result<(), TuimeError> {
     };
     let mut stdout = std::io::stdout();
     
+    stdout.queue(BeginSynchronizedUpdate).unwrap();
     if height != cfg.height.get() || width != cfg.width.get() {
         stdout.queue(terminal::Clear(terminal::ClearType::All)).unwrap();
         cfg.height.set(height);
         cfg.width.set(width);
     }
-    stdout.queue(BeginSynchronizedUpdate).unwrap();
     for (line_nr, line) in time_str.iter().enumerate() {
         stdout
         .queue(cursor::MoveTo(

--- a/src/display.rs
+++ b/src/display.rs
@@ -44,7 +44,7 @@ pub fn print_time(args: &Args, cfg: &Config) -> Result<(), TuimeError> {
     };
     let mut stdout = std::io::stdout();
 
-    crossterm::queue!(stdout, terminal::Clear(terminal::ClearType::All),).unwrap();
+    //crossterm::queue!(stdout, terminal::Clear(terminal::ClearType::All),).unwrap();
     for (line_nr, line) in time_str.iter().enumerate() {
         stdout
             .queue(cursor::MoveTo(

--- a/src/display.rs
+++ b/src/display.rs
@@ -44,19 +44,18 @@ pub fn print_time(args: &Args, cfg: &Config) -> Result<(), TuimeError> {
     };
     let mut stdout = std::io::stdout();
 
-    //crossterm::queue!(stdout, terminal::Clear(terminal::ClearType::All),).unwrap();
     for (line_nr, line) in time_str.iter().enumerate() {
         stdout
-            .queue(cursor::MoveTo(
-                0,
-                (line_nr + (height - highest_col) / 2)
-                    .try_into()
-                    .map_err(|_| TuimeError::WindowTooSmall(width, height))?,
-            ))
-            .unwrap();
-        crossterm::queue!(stdout, Print(line),).unwrap();
+        .queue(cursor::MoveTo(
+            0,
+            (line_nr + (height - highest_col) / 2)
+            .try_into()
+            .map_err(|_| TuimeError::WindowTooSmall(width, height))?,
+        ))
+        .unwrap();
+        crossterm::queue!(stdout, terminal::Clear(terminal::ClearType::CurrentLine), Print(line)).unwrap();
+        stdout.flush().unwrap();
     }
 
-    stdout.flush().unwrap();
     Ok(())
 }


### PR DESCRIPTION
# Changes:
- When a screen update begins, emit the BeginSynchronizedUpdate Sequence for Terminal Emulators that support it.
- During the screen update, if the screenbuffersize doesnt match the screenbuffersize detected during the previous update, clear the entire screenbuffer.
- During the screen update, for each line, print the padded line and then clear everything from the cursor to the end of the line in the screenbuffer.
- When all lines are printed, emit the EndSynchronizedUpdate Sequence for all Terminal Emulators that support it.
